### PR TITLE
build: update TelemetryDeck/SwiftSDK to v2.12.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,5 +72,5 @@ EventKit for reminders.
 
 ## Dependencies
 
-- **TelemetryDeck** (v2.9.4) — Privacy-first analytics
+- **TelemetryDeck** (v2.12.0) — Privacy-first analytics
 - **fastlane** — Build automation (Ruby gem)

--- a/KFinder.xcodeproj/project.pbxproj
+++ b/KFinder.xcodeproj/project.pbxproj
@@ -664,7 +664,7 @@
 			repositoryURL = "https://github.com/TelemetryDeck/SwiftSDK";
 			requirement = {
 				kind = exactVersion;
-				version = 2.11.0;
+				version = 2.12.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/KFinder.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/KFinder.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/TelemetryDeck/SwiftSDK",
       "state" : {
-        "revision" : "8f332c1c256ba26cc46f74c9e5af94f7b1c37a9c",
-        "version" : "2.11.0"
+        "revision" : "d41d6e86265dc182ba4474f9ef53ecddbbe052b8",
+        "version" : "2.12.0"
       }
     }
   ],


### PR DESCRIPTION
## Summary
- Upgrades TelemetryDeck/SwiftSDK from 2.11.0 to 2.12.0 (latest)
- Updates `CLAUDE.md` dependency reference to v2.12.0

## Test plan
- [x] `xcodebuild test` passes on iPhone Air / iOS 26.4
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)