### PR TITLE
fix: prune recently viewed FoodItems when exceeding recentFoodsLimit (#86)

### DIFF
--- a/KFinder/Application/Tabs/Foods/FoodDetailView.swift
+++ b/KFinder/Application/Tabs/Foods/FoodDetailView.swift
@@ -5,6 +5,7 @@
 
 import Models
 import OSLog
+import Services
 import SwiftData
 import SwiftUI
 
@@ -52,6 +53,8 @@ struct FoodDetailView: View {
         food.updatedAt = Date.now
         context.insert(food)
       }
+      try? context.save()
+      UserPreferences.shared.enforceRecentFoodsLimit()
     }
   }
 }

--- a/Packages/Services/Sources/Services/UserPreferences.swift
+++ b/Packages/Services/Sources/Services/UserPreferences.swift
@@ -44,7 +44,12 @@ import SwiftUI
   }
 
   public var recentFoodsLimit: Int = 5 {
-    didSet { save() }
+    didSet {
+      save()
+      if !isLoading {
+        enforceRecentFoodsLimit()
+      }
+    }
   }
 
   private init() {}
@@ -113,6 +118,8 @@ import SwiftUI
     defaultProTimeReminderTitle = settings.defaultProTimeReminderTitle
     proTimeReminderId = settings.proTimeReminderId
     recentFoodsLimit = settings.recentFoodsLimit
+
+    enforceRecentFoodsLimit()
   }
 
   private func migrateFromCloudStorage() -> UserSettings {
@@ -159,6 +166,27 @@ import SwiftUI
       try modelContext?.save()
     } catch {
       logger.error("save failed: \(error)")
+    }
+  }
+
+  public func enforceRecentFoodsLimit() {
+    guard let modelContext else { return }
+    let limit = recentFoodsLimit
+    let descriptor = FetchDescriptor<FoodItem>(
+      sortBy: [.init(\.updatedAt, order: .forward)]
+    )
+    do {
+      let items = try modelContext.fetch(descriptor)
+      if items.count > limit {
+        let toDelete = items.prefix(items.count - limit)
+        for item in toDelete {
+          modelContext.delete(item)
+        }
+        try? modelContext.save()
+        logger.debug("enforceRecentFoodsLimit: pruned \(toDelete.count) FoodItem record(s) to limit \(limit)")
+      }
+    } catch {
+      logger.error("enforceRecentFoodsLimit failed: \(error)")
     }
   }
 }


### PR DESCRIPTION
## Summary

The recent foods feature (Home tab) was causing full `FoodItem` objects (with nutrients + measures) to accumulate forever in the SwiftData + CloudKit store. The `recentFoodsLimit` setting (3–10) only limited the display query; there was no pruning logic at all.

## Changes

- New `enforceRecentFoodsLimit()` helper in `UserPreferences` (fetches oldest-first and deletes excess).
- Wired into limit changes, app launch / settings load, and `FoodDetailView` after a food is viewed.

## Testing

- `swiftlint` clean on the changed files.
- Built and ran successfully via XcodeBuildMCP (`build_run_sim`) on iPhone Air simulator.
- Pruning is exercised on every food view (after the limit) and on limit decreases.

Closes #86