### PR TITLE
feat: add RecentFood SwiftData model for Recents storage split (#92)

### DIFF
--- a/KFinder/Application/Main/KFinderApp.swift
+++ b/KFinder/Application/Main/KFinderApp.swift
@@ -26,7 +26,8 @@ struct KFinderApp: App {
     TelemetryDeck.signal("app.launched")
 
     do {
-      container = try ModelContainer(for: FoodItem.self, UserSettings.self)
+      container = try ModelContainer(
+        for: FoodItem.self, RecentFood.self, UserSettings.self)
     } catch {
       fatalError("Failed to create ModelContainer: \(error)")
     }

--- a/KFinder/Application/Tabs/Foods/FoodDetailView.swift
+++ b/KFinder/Application/Tabs/Foods/FoodDetailView.swift
@@ -11,7 +11,7 @@ import SwiftUI
 
 struct FoodDetailView: View {
   @Environment(\.modelContext) private var context
-  @Query private var foods: [FoodItem]
+  @Query private var recents: [RecentFood]
   @State var food: FoodItem
 
   private let logger = Logger(
@@ -20,8 +20,8 @@ struct FoodDetailView: View {
 
   init(food: FoodItem) {
     self.food = food
-    let id = food.id
-    _foods = Query(filter: #Predicate<FoodItem> { $0.id == id })
+    let fdcId = food.id
+    _recents = Query(filter: #Predicate<RecentFood> { $0.fdcId == fdcId })
   }
 
   var body: some View {
@@ -45,13 +45,15 @@ struct FoodDetailView: View {
       FoodNutrientListView(food: food)
     }
     .onAppear {
-      if let stored = foods.first {
-        logger.debug("Updating stored food item: '[\(food.id)]  \(food.name)'")
-        stored.updatedAt = Date.now
+      let vitaminKPer100g = helper.sumOfVitaminKValues
+      if let stored = recents.first {
+        logger.debug("Updating recent food: '[\(food.id)]  \(food.name)'")
+        stored.viewedAt = .now
+        stored.vitaminKPer100g = vitaminKPer100g
       } else {
-        logger.debug("Storing new food item: '[\(food.id)]  \(food.name)'")
-        food.updatedAt = Date.now
-        context.insert(food)
+        logger.debug("Storing new recent food: '[\(food.id)]  \(food.name)'")
+        context.insert(
+          RecentFood(from: food, vitaminKPer100g: vitaminKPer100g))
       }
       try? context.save()
       UserPreferences.shared.enforceRecentFoodsLimit()

--- a/KFinder/Application/Tabs/Home/RecentFoodCellView.swift
+++ b/KFinder/Application/Tabs/Home/RecentFoodCellView.swift
@@ -34,8 +34,8 @@ struct RecentFoodCellView: View {
 
   private var vitaminKPercent: Double {
     let target = userPreferences.dailyKTarget
-    guard let k = food.vitaminKPer100g, k > 0, target > 0 else { return 0 }
-    return k / target
+    guard let vitaminK = food.vitaminKPer100g, vitaminK > 0, target > 0 else { return 0 }
+    return vitaminK / target
   }
 
   private var vitaminKColor: Color {

--- a/KFinder/Application/Tabs/Home/RecentFoodCellView.swift
+++ b/KFinder/Application/Tabs/Home/RecentFoodCellView.swift
@@ -1,0 +1,58 @@
+//
+// SPDX-FileCopyrightText: (c) 2026 Robert Tucker
+// SPDX-License-Identifier: MIT
+//
+
+import Models
+import Services
+import SwiftUI
+
+struct RecentFoodCellView: View {
+  @Environment(UserPreferences.self) private var userPreferences
+
+  let food: RecentFood
+
+  var body: some View {
+    HStack {
+      VStack(alignment: .leading) {
+        Text(food.name)
+          .font(.headline)
+        Text(food.category ?? "")
+          .font(.subheadline)
+      }
+      Spacer()
+      Image(
+        systemName: "ellipsis.circle",
+        variableValue: vitaminKPercent
+      )
+      .symbolRenderingMode(.monochrome)
+      .foregroundColor(vitaminKColor)
+      .font(.title)
+    }
+    .padding(.horizontal)
+  }
+
+  private var vitaminKPercent: Double {
+    let target = userPreferences.dailyKTarget
+    guard let k = food.vitaminKPer100g, k > 0, target > 0 else { return 0 }
+    return k / target
+  }
+
+  private var vitaminKColor: Color {
+    switch vitaminKPercent * 100 {
+    case 0: return .gray
+    case 1..<25: return .green
+    case 25..<50: return .yellow
+    case 50..<75: return .orange
+    case 75...: return .red
+    default: return .gray
+    }
+  }
+}
+
+#if DEBUG
+  #Preview {
+    RecentFoodCellView(food: RecentFood.samples[1])
+      .environment(UserPreferences.shared)
+  }
+#endif

--- a/KFinder/Application/Tabs/Home/RecentFoodsListView.swift
+++ b/KFinder/Application/Tabs/Home/RecentFoodsListView.swift
@@ -13,12 +13,12 @@ struct RecentFoodsListView: View {
   @Environment(\.modelContext) private var modelContext
   @Environment(\.defaultMinListRowHeight) var minRowHeight
 
-  @Query(RecentFoodsListView.fetchDescriptor) private var foods: [FoodItem]
+  @Query(RecentFoodsListView.fetchDescriptor) private var foods: [RecentFood]
 
-  static var fetchDescriptor: FetchDescriptor<FoodItem> {
-    var descriptor = FetchDescriptor<FoodItem>(
+  static var fetchDescriptor: FetchDescriptor<RecentFood> {
+    var descriptor = FetchDescriptor<RecentFood>(
       sortBy: [
-        .init(\.updatedAt, order: .reverse)
+        .init(\.viewedAt, order: .reverse)
       ]
     )
     descriptor.fetchLimit = UserPreferences.shared.recentFoodsLimit
@@ -28,22 +28,21 @@ struct RecentFoodsListView: View {
   var body: some View {
     if foods.count > 0 {
       ForEach(foods, id: \.self) { food in
-        NavigationLink(destination: FoodDetailView(food: food)) {
-          FoodsListCellView(food: food)
-            .padding(.vertical)
-        }
-        .background(
-          RoundedRectangle(cornerRadius: .cornerRadius)
-            .fill(Color.appBackground(for: colorScheme))
-            .withCardShadow()
-        )
-        .contextMenu {
-          Button {
-            modelContext.delete(food)
-          } label: {
-            Label("foods.recent.remove", systemImage: "trash")
+        // Tap-through to detail is restored by #96 (fetchFood by fdcId).
+        RecentFoodCellView(food: food)
+          .padding(.vertical)
+          .background(
+            RoundedRectangle(cornerRadius: .cornerRadius)
+              .fill(Color.appBackground(for: colorScheme))
+              .withCardShadow()
+          )
+          .contextMenu {
+            Button {
+              modelContext.delete(food)
+            } label: {
+              Label("foods.recent.remove", systemImage: "trash")
+            }
           }
-        }
       }
     } else {
       VStack(alignment: .leading) {

--- a/Packages/Models/Sources/Models/RecentFood.swift
+++ b/Packages/Models/Sources/Models/RecentFood.swift
@@ -62,7 +62,7 @@ import SwiftData
         category: "Other vegetables and combinations",
         dataType: "Survey (FNDDS)",
         vitaminKPer100g: 74.1
-      ),
+      )
     ]
   }
 #endif

--- a/Packages/Models/Sources/Models/RecentFood.swift
+++ b/Packages/Models/Sources/Models/RecentFood.swift
@@ -1,0 +1,68 @@
+//
+// SPDX-FileCopyrightText: (c) 2026 Robert Tucker
+// SPDX-License-Identifier: MIT
+//
+
+import Foundation
+import SwiftData
+
+// Device-local by design (no CloudKit). Recents reflect inherently
+// per-device context — what was looked up on iPad isn't necessarily
+// "recent" on iPhone — and keeping recents off CloudKit aligns with
+// the storage-split epic's iCloud-cost story. See issue #92.
+@Model public class RecentFood: Equatable {
+  public var fdcId: Int = 0
+  public var name: String = ""
+  public var category: String?
+  public var dataType: String = ""
+  public var vitaminKPer100g: Double?
+  public var viewedAt: Date = Date.now
+
+  public init(
+    fdcId: Int,
+    name: String,
+    category: String? = nil,
+    dataType: String,
+    vitaminKPer100g: Double? = nil,
+    viewedAt: Date = .now
+  ) {
+    self.fdcId = fdcId
+    self.name = name
+    self.category = category
+    self.dataType = dataType
+    self.vitaminKPer100g = vitaminKPer100g
+    self.viewedAt = viewedAt
+  }
+
+  public convenience init(from food: FoodItem, vitaminKPer100g: Double?) {
+    self.init(
+      fdcId: food.id,
+      name: food.name,
+      category: food.category,
+      dataType: food.dataType,
+      vitaminKPer100g: vitaminKPer100g,
+      viewedAt: .now
+    )
+  }
+}
+
+#if DEBUG
+  extension RecentFood {
+    nonisolated(unsafe) public static let samples = [
+      RecentFood(
+        fdcId: 2_341_130,
+        name: "Cheese, Muenster, reduced fat",
+        category: "Cheese",
+        dataType: "Survey (FNDDS)",
+        vitaminKPer100g: 1.5
+      ),
+      RecentFood(
+        fdcId: 2_345_430,
+        name: "Fennel bulb, cooked",
+        category: "Other vegetables and combinations",
+        dataType: "Survey (FNDDS)",
+        vitaminKPer100g: 74.1
+      ),
+    ]
+  }
+#endif

--- a/Packages/Services/Sources/Services/UserPreferences.swift
+++ b/Packages/Services/Sources/Services/UserPreferences.swift
@@ -172,8 +172,8 @@ import SwiftUI
   public func enforceRecentFoodsLimit() {
     guard let modelContext else { return }
     let limit = recentFoodsLimit
-    let descriptor = FetchDescriptor<FoodItem>(
-      sortBy: [.init(\.updatedAt, order: .forward)]
+    let descriptor = FetchDescriptor<RecentFood>(
+      sortBy: [.init(\.viewedAt, order: .forward)]
     )
     do {
       let items = try modelContext.fetch(descriptor)
@@ -183,7 +183,7 @@ import SwiftUI
           modelContext.delete(item)
         }
         try? modelContext.save()
-        logger.debug("enforceRecentFoodsLimit: pruned \(toDelete.count) FoodItem record(s) to limit \(limit)")
+        logger.debug("enforceRecentFoodsLimit: pruned \(toDelete.count) RecentFood record(s) to limit \(limit)")
       }
     } catch {
       logger.error("enforceRecentFoodsLimit failed: \(error)")


### PR DESCRIPTION
## Summary

First sub-issue of the Recents/Favorites storage split epic (#50). Introduces a lightweight `RecentFood` SwiftData model distinct from `FoodItem` and swaps the detail-view write path, recents read path, and pruning to the new model.

- **Model:** `fdcId, name, category, dataType, vitaminKPer100g?, viewedAt`. Device-local (no CloudKit) — rationale documented in `RecentFood.swift`.
- **Cell:** new `RecentFoodCellView` mirroring `FoodsListCellView` but reading the cached K value rather than summing nutrients. Search results keep using the original cell.
- **Tap-through:** disabled on Recents rows until #96 lands `fetchFood(by fdcId:)`. The plain card matches the design choice for this transition window.
- **Out of scope:** migration of existing `FoodItem`-as-Recent records (#97), pruning policy (#95), re-open path (#96).

Closes #92. Refs #50.

## Test plan

- [x] Build clean (no warnings/errors)
- [x] App launches; `ModelContainer` registers `RecentFood` without migration error
- [x] Search → tap result → `.onAppear` writes a `RecentFood` (verified via log: `Storing new recent food: '[2709632] Channa Saag'`)
- [x] Home Recents renders the new row with cached `vitaminKPer100g` driving the K% indicator color
- [ ] Existing users will see an empty Recents list once (expected; #97 handles migration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)