### PR TITLE
ci: cache SwiftPM dependencies and drop redundant clean

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,5 +20,15 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
+      - name: Cache SwiftPM dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/Library/Caches/org.swift.swiftpm
+            ~/Library/Developer/Xcode/DerivedData/**/SourcePackages
+          key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-spm-
+
       - name: Build and Test
-        run: set -o pipefail && xcodebuild clean test -scheme KFinder -project KFinder.xcodeproj -destination "platform=iOS Simulator,OS=26.2,name=iPhone Air" | xcpretty && exit ${PIPESTATUS[0]}
+        run: set -o pipefail && xcodebuild test -scheme KFinder -project KFinder.xcodeproj -destination "platform=iOS Simulator,OS=26.2,name=iPhone Air" | xcpretty && exit ${PIPESTATUS[0]}


### PR DESCRIPTION
## Summary

Two small CI tweaks to speed up the build job:

1. **Drop `clean`** from the xcodebuild invocation. GitHub macOS runners are fresh per job, so the leading `clean` was a no-op against the runner but a guaranteed cache-invalidator if any cache were added — removing it unblocks tier 2.
2. **Cache SwiftPM dependencies** via `actions/cache@v4`, keyed on `Package.resolved`. Caches both the global SwiftPM cache and the resolved/compiled `SourcePackages` under DerivedData. A partial-restore key (`${{ runner.os }}-spm-`) means dep bumps degrade gracefully instead of starting from scratch.

Expected savings: **1-3 minutes** on the cold build (the warm cache hit will tell us the real number on the second run against this branch).

## Test plan

- [ ] CI run against this PR succeeds (first run = cache populated)
- [ ] Second CI run (e.g., a trivial follow-up commit) shows the cache hit and shorter dependency-resolution time
- [ ] No regression in existing tests

## Notes

Tier 3 (full DerivedData cache via `irgaly/xcode-cache`) was discussed but deferred — fragile cache keys and partial hits are common; revisit if this PR doesn't move the needle enough.

🤖 Generated with [Claude Code](https://claude.com/claude-code)