### PR TITLE
feat: migrate FoodItem-as-Recent records to RecentFood (#97)

### DIFF
--- a/KFinder/Application/Main/KFinderApp.swift
+++ b/KFinder/Application/Main/KFinderApp.swift
@@ -31,6 +31,7 @@ struct KFinderApp: App {
     } catch {
       fatalError("Failed to create ModelContainer: \(error)")
     }
+    RecentFoodMigrator.migrateIfNeeded(in: container)
     UserPreferences.shared.configure(with: container)
   }
 }

--- a/Packages/Models/Sources/Models/RecentFood.swift
+++ b/Packages/Models/Sources/Models/RecentFood.swift
@@ -44,6 +44,17 @@ import SwiftData
       viewedAt: .now
     )
   }
+
+  // FDC nutrient numbers 428/429/430 are the vitamin K family
+  // (menaquinone-4, dihydrophylloquinone, phylloquinone). Values
+  // are reported per 100 g, so summing matches the cache contract.
+  public static func vitaminKPer100g(from nutrients: [FoodNutrient]?) -> Double? {
+    guard let nutrients else { return nil }
+    let sum = nutrients
+      .filter { ["428", "429", "430"].contains($0.number) }
+      .reduce(0.0) { $0 + $1.value }
+    return sum > 0 ? sum : nil
+  }
 }
 
 #if DEBUG

--- a/Packages/Services/Sources/Services/RecentFoodMigrator.swift
+++ b/Packages/Services/Sources/Services/RecentFoodMigrator.swift
@@ -1,0 +1,81 @@
+//
+// SPDX-FileCopyrightText: (c) 2026 Robert Tucker
+// SPDX-License-Identifier: MIT
+//
+
+import Foundation
+import Models
+import OSLog
+import SwiftData
+
+public enum RecentFoodMigrator {
+  private static let migrationFlagKey = "RecentFoodMigrationCompleted_v1"
+
+  private static let logger = Logger(
+    subsystem: Bundle.main.bundleIdentifier ?? "dev.eclectic.KFinder",
+    category: "RecentFoodMigrator"
+  )
+
+  @MainActor
+  public static func migrateIfNeeded(in container: ModelContainer) {
+    let defaults = UserDefaults.standard
+    guard !defaults.bool(forKey: migrationFlagKey) else { return }
+
+    let context = container.mainContext
+    let start = Date.now
+
+    let foodItems: [FoodItem]
+    do {
+      foodItems = try context.fetch(
+        FetchDescriptor<FoodItem>(
+          sortBy: [.init(\.updatedAt, order: .reverse)]
+        )
+      )
+    } catch {
+      logger.error("migration fetch failed: \(error)")
+      return
+    }
+
+    guard !foodItems.isEmpty else {
+      defaults.set(true, forKey: migrationFlagKey)
+      logger.debug("no FoodItem records; marking migration complete")
+      return
+    }
+
+    let limit = UserPreferences.shared.recentFoodsLimit
+    let keep = foodItems.prefix(limit)
+
+    for item in keep {
+      let recent = RecentFood(
+        fdcId: item.id,
+        name: item.name,
+        category: item.category,
+        dataType: item.dataType,
+        vitaminKPer100g: RecentFood.vitaminKPer100g(from: item.nutrients),
+        viewedAt: item.updatedAt
+      )
+      context.insert(recent)
+    }
+
+    // Delete ALL FoodItem records, not just the ones past the cap.
+    // The relationship rules on FoodItem cascade to FoodNutrient and
+    // FoodMeasure, so this also frees the per-nutrient/measure rows
+    // that were the bulk of the storage footprint.
+    for item in foodItems {
+      context.delete(item)
+    }
+
+    do {
+      try context.save()
+    } catch {
+      logger.error("migration save failed: \(error)")
+      return
+    }
+
+    defaults.set(true, forKey: migrationFlagKey)
+    let elapsedMs = Int(Date.now.timeIntervalSince(start) * 1000)
+    logger.debug(
+      "migrated \(keep.count) of \(foodItems.count) FoodItem record(s) to RecentFood in \(elapsedMs) ms"
+    )
+  }
+}


### PR DESCRIPTION
## Summary

Second sub-issue of the Recents/Favorites storage split epic (#50). One-shot migration that runs on first launch after #92 ships, converting any existing `FoodItem` records (which, pre-#92, were the Recents store) into the new lightweight `RecentFood` model.

- **Migrator** (`Packages/Services/Sources/Services/RecentFoodMigrator.swift`) — runs in `KFinderApp.init` between container creation and `UserPreferences.configure`. Guarded by `UserDefaults` flag `RecentFoodMigrationCompleted_v1`.
- **Field projection** — `fdcId, name, category, dataType, vitaminKPer100g, viewedAt` (the last sourced from `FoodItem.updatedAt`).
- **K extraction** — new `RecentFood.vitaminKPer100g(from: [FoodNutrient]?)` static helper in Models, callable from anywhere that doesn't have the app-target's `FoodDisplayHelper`. Same nutrient-number contract (428/429/430).
- **Cleanup** — all `FoodItem` rows are deleted post-migration; the cascade rule on `FoodItem.nutrients`/`measures` frees the relationship rows that were the bulk of the storage footprint.
- **Capping** — applies `recentFoodsLimit` on the way in (sort newest-first, take prefix), avoiding insert-then-prune.

Closes #97. Refs #50.

## Test plan

Verified end-to-end on iOS Simulator (iPhone Air):

- [x] Build clean, lint passes `--strict`
- [x] Seed: uninstalled app, switched to pre-#92 commit (`1173ae6`), populated 3 Recents via real FDC search → tap flow
- [x] Switch to this branch, build + launch → migration ran on first launch
- [x] Home Recents shows all 3 migrated records in correct newest-first order
- [x] K% indicator colors match underlying values (green for ~10-14µg)
- [x] Categories preserved
- [x] Re-launch: identical screen, no record duplication (idempotent guard works)
- [x] `UserDefaults` flag `RecentFoodMigrationCompleted_v1 = true` written to app's preference plist
- [ ] Over-limit case (N > recentFoodsLimit → kept N=5) — code path is `Array.prefix(limit)`, validated by inspection rather than seeded test
- [ ] Fresh-install no-op path — code path is the empty-array branch, validated by inspection

## Notes

- The K extraction in `FoodDisplayHelper` still uses its own regex form; deduplicating against the new `RecentFood.vitaminKPer100g(from:)` is a small follow-up worth considering but out of scope.
- `FoodItem` model is still registered in `ModelContainer` because `FoodDetailView` still receives it as input from search results. Removing it would be a separate cleanup once the search-to-detail flow is reconsidered (likely #96 territory).

🤖 Generated with [Claude Code](https://claude.com/claude-code)