### PR TITLE
feat: bound RecentFood store size, not just the query (#95)

### DIFF
--- a/KFinder/Application/Tabs/Foods/FoodDetailView.swift
+++ b/KFinder/Application/Tabs/Foods/FoodDetailView.swift
@@ -56,6 +56,7 @@ struct FoodDetailView: View {
           RecentFood(from: food, vitaminKPer100g: vitaminKPer100g))
       }
       try? context.save()
+      // Write-time prune — bounds the store, not the fetch (#95).
       UserPreferences.shared.enforceRecentFoodsLimit()
     }
   }

--- a/KFinder/Application/Tabs/Home/RecentFoodsListView.swift
+++ b/KFinder/Application/Tabs/Home/RecentFoodsListView.swift
@@ -13,17 +13,9 @@ struct RecentFoodsListView: View {
   @Environment(\.modelContext) private var modelContext
   @Environment(\.defaultMinListRowHeight) var minRowHeight
 
-  @Query(RecentFoodsListView.fetchDescriptor) private var foods: [RecentFood]
-
-  static var fetchDescriptor: FetchDescriptor<RecentFood> {
-    var descriptor = FetchDescriptor<RecentFood>(
-      sortBy: [
-        .init(\.viewedAt, order: .reverse)
-      ]
-    )
-    descriptor.fetchLimit = UserPreferences.shared.recentFoodsLimit
-    return descriptor
-  }
+  // Store is bounded by `UserPreferences.enforceRecentFoodsLimit()` (#95);
+  // no `fetchLimit` needed here.
+  @Query(sort: \RecentFood.viewedAt, order: .reverse) private var foods: [RecentFood]
 
   var body: some View {
     if foods.count > 0 {

--- a/KFinderTests/EnforceRecentFoodsLimitTests.swift
+++ b/KFinderTests/EnforceRecentFoodsLimitTests.swift
@@ -1,0 +1,112 @@
+//
+// SPDX-FileCopyrightText: (c) 2026 Robert Tucker
+// SPDX-License-Identifier: MIT
+//
+
+import Foundation
+import Models
+import Services
+import SwiftData
+import Testing
+
+// Drives the static `UserPreferences.enforceRecentFoodsLimit(in:limit:)`
+// directly so tests don't go through the singleton's configure/observer
+// lifecycle (which leaks observers across tests in the same host process).
+@Suite("enforceRecentFoodsLimit")
+@MainActor
+struct EnforceRecentFoodsLimitTests {
+
+  private func makeContainer() throws -> ModelContainer {
+    try ModelContainer(
+      for: RecentFood.self,
+      configurations: ModelConfiguration(isStoredInMemoryOnly: true)
+    )
+  }
+
+  private func insertRecent(
+    _ context: ModelContext, fdcId: Int, viewedAt: Date
+  ) {
+    context.insert(
+      RecentFood(
+        fdcId: fdcId,
+        name: "food-\(fdcId)",
+        dataType: "Survey (FNDDS)",
+        viewedAt: viewedAt))
+  }
+
+  @Test("prunes to limit when over by one")
+  func prunesOverByOne() throws {
+    let container = try makeContainer()
+    let context = container.mainContext
+    let base = Date(timeIntervalSince1970: 1_700_000_000)
+    for index in 0..<6 {
+      insertRecent(
+        context, fdcId: 1000 + index,
+        viewedAt: base.addingTimeInterval(TimeInterval(index)))
+    }
+    try context.save()
+
+    UserPreferences.enforceRecentFoodsLimit(in: context, limit: 5)
+
+    let remaining = try context.fetch(FetchDescriptor<RecentFood>())
+    #expect(remaining.count == 5)
+  }
+
+  @Test("evicts oldest viewedAt first")
+  func evictsOldestFirst() throws {
+    let container = try makeContainer()
+    let context = container.mainContext
+    let base = Date(timeIntervalSince1970: 1_700_000_000)
+    // fdcId chosen so insert order != viewedAt order — guards against
+    // the prune accidentally relying on insertion order.
+    insertRecent(context, fdcId: 5, viewedAt: base.addingTimeInterval(100))
+    insertRecent(context, fdcId: 1, viewedAt: base.addingTimeInterval(10))
+    insertRecent(context, fdcId: 4, viewedAt: base.addingTimeInterval(80))
+    insertRecent(context, fdcId: 2, viewedAt: base.addingTimeInterval(20))
+    insertRecent(context, fdcId: 3, viewedAt: base.addingTimeInterval(60))
+    try context.save()
+
+    UserPreferences.enforceRecentFoodsLimit(in: context, limit: 3)
+
+    let survivingIds = Set(
+      try context.fetch(FetchDescriptor<RecentFood>()).map(\.fdcId))
+    #expect(survivingIds == [3, 4, 5])
+  }
+
+  @Test("resolves equal-viewedAt ties by fdcId")
+  func tieResolution() throws {
+    let container = try makeContainer()
+    let context = container.mainContext
+    let sameInstant = Date(timeIntervalSince1970: 1_700_000_000)
+    // Four records share `viewedAt`. Lower fdcId sorts earlier → evicted first.
+    insertRecent(context, fdcId: 10, viewedAt: sameInstant)
+    insertRecent(context, fdcId: 20, viewedAt: sameInstant)
+    insertRecent(context, fdcId: 30, viewedAt: sameInstant)
+    insertRecent(context, fdcId: 40, viewedAt: sameInstant)
+    try context.save()
+
+    UserPreferences.enforceRecentFoodsLimit(in: context, limit: 2)
+
+    let survivingIds = Set(
+      try context.fetch(FetchDescriptor<RecentFood>()).map(\.fdcId))
+    #expect(survivingIds == [30, 40])
+  }
+
+  @Test("no-op when count is at or below limit")
+  func noOpUnderLimit() throws {
+    let container = try makeContainer()
+    let context = container.mainContext
+    let base = Date(timeIntervalSince1970: 1_700_000_000)
+    for index in 0..<3 {
+      insertRecent(
+        context, fdcId: 1000 + index,
+        viewedAt: base.addingTimeInterval(TimeInterval(index)))
+    }
+    try context.save()
+
+    UserPreferences.enforceRecentFoodsLimit(in: context, limit: 5)
+
+    let remaining = try context.fetch(FetchDescriptor<RecentFood>())
+    #expect(remaining.count == 3)
+  }
+}

--- a/KFinderTests/KFinderTests.swift
+++ b/KFinderTests/KFinderTests.swift
@@ -6,7 +6,6 @@
 import Foundation
 import Models
 import Services
-import SwiftData
 import Testing
 
 @testable import KFinder
@@ -361,109 +360,5 @@ struct TestReminderModelTests {
     let reminder = Reminder(title: "Test", dueDate: futureDate)
     let model = TestReminderModel(reminder)
     #expect(model.isOverDue() == false)
-  }
-}
-
-// MARK: - enforceRecentFoodsLimit Tests
-
-// Drives the static `UserPreferences.enforceRecentFoodsLimit(in:limit:)`
-// directly so tests don't go through the singleton's configure/observer
-// lifecycle (which leaks observers across tests in the same host process).
-@Suite("enforceRecentFoodsLimit")
-@MainActor
-struct EnforceRecentFoodsLimitTests {
-
-  private func makeContainer() throws -> ModelContainer {
-    try ModelContainer(
-      for: RecentFood.self,
-      configurations: ModelConfiguration(isStoredInMemoryOnly: true)
-    )
-  }
-
-  private func insertRecent(
-    _ context: ModelContext, fdcId: Int, viewedAt: Date
-  ) {
-    context.insert(
-      RecentFood(
-        fdcId: fdcId,
-        name: "food-\(fdcId)",
-        dataType: "Survey (FNDDS)",
-        viewedAt: viewedAt))
-  }
-
-  @Test("prunes to limit when over by one")
-  func prunesOverByOne() throws {
-    let container = try makeContainer()
-    let context = container.mainContext
-    let base = Date(timeIntervalSince1970: 1_700_000_000)
-    for index in 0..<6 {
-      insertRecent(
-        context, fdcId: 1000 + index,
-        viewedAt: base.addingTimeInterval(TimeInterval(index)))
-    }
-    try context.save()
-
-    UserPreferences.enforceRecentFoodsLimit(in: context, limit: 5)
-
-    let remaining = try context.fetch(FetchDescriptor<RecentFood>())
-    #expect(remaining.count == 5)
-  }
-
-  @Test("evicts oldest viewedAt first")
-  func evictsOldestFirst() throws {
-    let container = try makeContainer()
-    let context = container.mainContext
-    let base = Date(timeIntervalSince1970: 1_700_000_000)
-    // fdcId chosen so insert order != viewedAt order — guards against
-    // the prune accidentally relying on insertion order.
-    insertRecent(context, fdcId: 5, viewedAt: base.addingTimeInterval(100))
-    insertRecent(context, fdcId: 1, viewedAt: base.addingTimeInterval(10))
-    insertRecent(context, fdcId: 4, viewedAt: base.addingTimeInterval(80))
-    insertRecent(context, fdcId: 2, viewedAt: base.addingTimeInterval(20))
-    insertRecent(context, fdcId: 3, viewedAt: base.addingTimeInterval(60))
-    try context.save()
-
-    UserPreferences.enforceRecentFoodsLimit(in: context, limit: 3)
-
-    let survivingIds = Set(
-      try context.fetch(FetchDescriptor<RecentFood>()).map(\.fdcId))
-    #expect(survivingIds == [3, 4, 5])
-  }
-
-  @Test("resolves equal-viewedAt ties by fdcId")
-  func tieResolution() throws {
-    let container = try makeContainer()
-    let context = container.mainContext
-    let sameInstant = Date(timeIntervalSince1970: 1_700_000_000)
-    // Four records share `viewedAt`. Lower fdcId sorts earlier → evicted first.
-    insertRecent(context, fdcId: 10, viewedAt: sameInstant)
-    insertRecent(context, fdcId: 20, viewedAt: sameInstant)
-    insertRecent(context, fdcId: 30, viewedAt: sameInstant)
-    insertRecent(context, fdcId: 40, viewedAt: sameInstant)
-    try context.save()
-
-    UserPreferences.enforceRecentFoodsLimit(in: context, limit: 2)
-
-    let survivingIds = Set(
-      try context.fetch(FetchDescriptor<RecentFood>()).map(\.fdcId))
-    #expect(survivingIds == [30, 40])
-  }
-
-  @Test("no-op when count is at or below limit")
-  func noOpUnderLimit() throws {
-    let container = try makeContainer()
-    let context = container.mainContext
-    let base = Date(timeIntervalSince1970: 1_700_000_000)
-    for index in 0..<3 {
-      insertRecent(
-        context, fdcId: 1000 + index,
-        viewedAt: base.addingTimeInterval(TimeInterval(index)))
-    }
-    try context.save()
-
-    UserPreferences.enforceRecentFoodsLimit(in: context, limit: 5)
-
-    let remaining = try context.fetch(FetchDescriptor<RecentFood>())
-    #expect(remaining.count == 3)
   }
 }

--- a/KFinderTests/KFinderTests.swift
+++ b/KFinderTests/KFinderTests.swift
@@ -6,6 +6,7 @@
 import Foundation
 import Models
 import Services
+import SwiftData
 import Testing
 
 @testable import KFinder
@@ -360,5 +361,109 @@ struct TestReminderModelTests {
     let reminder = Reminder(title: "Test", dueDate: futureDate)
     let model = TestReminderModel(reminder)
     #expect(model.isOverDue() == false)
+  }
+}
+
+// MARK: - enforceRecentFoodsLimit Tests
+
+// Drives the static `UserPreferences.enforceRecentFoodsLimit(in:limit:)`
+// directly so tests don't go through the singleton's configure/observer
+// lifecycle (which leaks observers across tests in the same host process).
+@Suite("enforceRecentFoodsLimit")
+@MainActor
+struct EnforceRecentFoodsLimitTests {
+
+  private func makeContainer() throws -> ModelContainer {
+    try ModelContainer(
+      for: RecentFood.self,
+      configurations: ModelConfiguration(isStoredInMemoryOnly: true)
+    )
+  }
+
+  private func insertRecent(
+    _ context: ModelContext, fdcId: Int, viewedAt: Date
+  ) {
+    context.insert(
+      RecentFood(
+        fdcId: fdcId,
+        name: "food-\(fdcId)",
+        dataType: "Survey (FNDDS)",
+        viewedAt: viewedAt))
+  }
+
+  @Test("prunes to limit when over by one")
+  func prunesOverByOne() throws {
+    let container = try makeContainer()
+    let context = container.mainContext
+    let base = Date(timeIntervalSince1970: 1_700_000_000)
+    for index in 0..<6 {
+      insertRecent(
+        context, fdcId: 1000 + index,
+        viewedAt: base.addingTimeInterval(TimeInterval(index)))
+    }
+    try context.save()
+
+    UserPreferences.enforceRecentFoodsLimit(in: context, limit: 5)
+
+    let remaining = try context.fetch(FetchDescriptor<RecentFood>())
+    #expect(remaining.count == 5)
+  }
+
+  @Test("evicts oldest viewedAt first")
+  func evictsOldestFirst() throws {
+    let container = try makeContainer()
+    let context = container.mainContext
+    let base = Date(timeIntervalSince1970: 1_700_000_000)
+    // fdcId chosen so insert order != viewedAt order — guards against
+    // the prune accidentally relying on insertion order.
+    insertRecent(context, fdcId: 5, viewedAt: base.addingTimeInterval(100))
+    insertRecent(context, fdcId: 1, viewedAt: base.addingTimeInterval(10))
+    insertRecent(context, fdcId: 4, viewedAt: base.addingTimeInterval(80))
+    insertRecent(context, fdcId: 2, viewedAt: base.addingTimeInterval(20))
+    insertRecent(context, fdcId: 3, viewedAt: base.addingTimeInterval(60))
+    try context.save()
+
+    UserPreferences.enforceRecentFoodsLimit(in: context, limit: 3)
+
+    let survivingIds = Set(
+      try context.fetch(FetchDescriptor<RecentFood>()).map(\.fdcId))
+    #expect(survivingIds == [3, 4, 5])
+  }
+
+  @Test("resolves equal-viewedAt ties by fdcId")
+  func tieResolution() throws {
+    let container = try makeContainer()
+    let context = container.mainContext
+    let sameInstant = Date(timeIntervalSince1970: 1_700_000_000)
+    // Four records share `viewedAt`. Lower fdcId sorts earlier → evicted first.
+    insertRecent(context, fdcId: 10, viewedAt: sameInstant)
+    insertRecent(context, fdcId: 20, viewedAt: sameInstant)
+    insertRecent(context, fdcId: 30, viewedAt: sameInstant)
+    insertRecent(context, fdcId: 40, viewedAt: sameInstant)
+    try context.save()
+
+    UserPreferences.enforceRecentFoodsLimit(in: context, limit: 2)
+
+    let survivingIds = Set(
+      try context.fetch(FetchDescriptor<RecentFood>()).map(\.fdcId))
+    #expect(survivingIds == [30, 40])
+  }
+
+  @Test("no-op when count is at or below limit")
+  func noOpUnderLimit() throws {
+    let container = try makeContainer()
+    let context = container.mainContext
+    let base = Date(timeIntervalSince1970: 1_700_000_000)
+    for index in 0..<3 {
+      insertRecent(
+        context, fdcId: 1000 + index,
+        viewedAt: base.addingTimeInterval(TimeInterval(index)))
+    }
+    try context.save()
+
+    UserPreferences.enforceRecentFoodsLimit(in: context, limit: 5)
+
+    let remaining = try context.fetch(FetchDescriptor<RecentFood>())
+    #expect(remaining.count == 3)
   }
 }

--- a/Packages/Services/Sources/Services/UserPreferences.swift
+++ b/Packages/Services/Sources/Services/UserPreferences.swift
@@ -183,7 +183,7 @@ import SwiftUI
     let descriptor = FetchDescriptor<RecentFood>(
       sortBy: [
         .init(\.viewedAt, order: .forward),
-        .init(\.fdcId, order: .forward),
+        .init(\.fdcId, order: .forward)
       ]
     )
     do {

--- a/Packages/Services/Sources/Services/UserPreferences.swift
+++ b/Packages/Services/Sources/Services/UserPreferences.swift
@@ -171,22 +171,32 @@ import SwiftUI
 
   public func enforceRecentFoodsLimit() {
     guard let modelContext else { return }
-    let limit = recentFoodsLimit
+    UserPreferences.enforceRecentFoodsLimit(
+      in: modelContext, limit: recentFoodsLimit, logger: logger)
+  }
+
+  // Static so callers (and tests) can prune any `ModelContext` without
+  // going through the singleton's configure/observer lifecycle.
+  public static func enforceRecentFoodsLimit(
+    in modelContext: ModelContext, limit: Int, logger: Logger? = nil
+  ) {
     let descriptor = FetchDescriptor<RecentFood>(
-      sortBy: [.init(\.viewedAt, order: .forward)]
+      sortBy: [
+        .init(\.viewedAt, order: .forward),
+        .init(\.fdcId, order: .forward),
+      ]
     )
     do {
       let items = try modelContext.fetch(descriptor)
-      if items.count > limit {
-        let toDelete = items.prefix(items.count - limit)
-        for item in toDelete {
-          modelContext.delete(item)
-        }
-        try? modelContext.save()
-        logger.debug("enforceRecentFoodsLimit: pruned \(toDelete.count) RecentFood record(s) to limit \(limit)")
+      guard items.count > limit else { return }
+      let toDelete = items.prefix(items.count - limit)
+      for item in toDelete {
+        modelContext.delete(item)
       }
+      try? modelContext.save()
+      logger?.debug("enforceRecentFoodsLimit: pruned \(toDelete.count) RecentFood record(s) to limit \(limit)")
     } catch {
-      logger.error("enforceRecentFoodsLimit failed: \(error)")
+      logger?.error("enforceRecentFoodsLimit failed: \(error)")
     }
   }
 }


### PR DESCRIPTION
## Summary

Closes #95.

- `enforceRecentFoodsLimit` now sorts by `(viewedAt, fdcId)` so equal-timestamp ties resolve deterministically.
- Extracted the prune logic into a static `UserPreferences.enforceRecentFoodsLimit(in:limit:)` helper. The instance method delegates. This lets callers (and tests) prune any `ModelContext` without going through the singleton's `configure`/observer lifecycle.
- Dropped `descriptor.fetchLimit` from `RecentFoodsListView`'s `@Query` — the store is now bounded at write time, so the read-side limit was redundant. Also fixes a latent bug where the static var captured the limit at first evaluation, not at render time.
- Added a one-line doc comment at `FoodDetailView.swift:60` (the write-time prune call site) pointing to #95.
- Tests (4) cover the AC: N+1 eviction, oldest-first, tie resolution by `fdcId`, and no-op-under-limit.

## Notes

- New tests live in `KFinderTests/KFinderTests.swift` (which actually runs on CI) rather than the orphaned `Packages/Services/Tests/ServicesTests/ServicesTests.swift`. The latter is not wired into the `KFinder` test scheme — discovered while writing these tests. Filed as a follow-up rather than expanding scope here.
- Along the way I uncovered two pre-existing production bugs in `UserPreferences` (singleton's `NSPersistentStoreRemoteChange` observer leaks across `configure(with:)` calls; `migrateFromCloudStorage` traps under non-iCloud bundles like xctest). Neither needed to be fixed for #95 — the static helper sidesteps both — but they should be tracked.

## Test plan

- [x] `xcodebuild test -scheme KFinder` green locally
- [x] 4 new prune tests pass in <60ms each
- [ ] CI green on this PR
- [ ] Manual smoke: launch app, visit ≥6 Foods, verify only `recentFoodsLimit` records remain in Recents

🤖 Generated with [Claude Code](https://claude.com/claude-code)