### PR TITLE
ci: bump simulator OS to 26.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,4 +31,4 @@ jobs:
             ${{ runner.os }}-spm-
 
       - name: Build and Test
-        run: set -o pipefail && xcodebuild test -scheme KFinder -project KFinder.xcodeproj -destination "platform=iOS Simulator,OS=26.2,name=iPhone Air" | xcpretty && exit ${PIPESTATUS[0]}
+        run: set -o pipefail && xcodebuild test -scheme KFinder -project KFinder.xcodeproj -destination "platform=iOS Simulator,OS=26.5,name=iPhone Air" | xcpretty && exit ${PIPESTATUS[0]}


### PR DESCRIPTION
## Summary

- Match the simulator we actually build against locally (`iPhone Air, OS:26.5`). CI was pinned to 26.2; the local Xcode install only has 26.5 sims, so any version-tied regression caught locally was invisible on CI and vice versa.

## Test plan

- [ ] CI green on this PR. If `macos-latest` runner doesn't have 26.5 sims installed, the destination won't resolve and we'll see a clear "Unable to find a device matching the provided destination specifier" — at which point we either pin to 26.4/26.3 or install the sim explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)