### PR TITLE
feat: rehydrate Recents on tap via FoodDataCentralService.fetchFood (#96)

### DIFF
--- a/KFinder/Application/Tabs/Home/RecentFoodsListView.swift
+++ b/KFinder/Application/Tabs/Home/RecentFoodsListView.swift
@@ -17,24 +17,63 @@ struct RecentFoodsListView: View {
   // no `fetchLimit` needed here.
   @Query(sort: \RecentFood.viewedAt, order: .reverse) private var foods: [RecentFood]
 
+  // Rehydrates a tapped Recent into a full `FoodItem` via the FDC detail
+  // endpoint; see issue #96.
+  private let service = FoodDataCentralService(
+    apiKey: Secrets.FoodDataCentral.apiKey ?? "")
+  @State private var loadingFdcId: Int?
+  @State private var navigationTarget: FoodItem?
+  @State private var fetchError: FetchError?
+
+  private struct FetchError: Identifiable {
+    let id = UUID()
+    let message: String
+  }
+
   var body: some View {
     if foods.count > 0 {
       ForEach(foods, id: \.self) { food in
-        // Tap-through to detail is restored by #96 (fetchFood by fdcId).
-        RecentFoodCellView(food: food)
-          .padding(.vertical)
-          .background(
-            RoundedRectangle(cornerRadius: .cornerRadius)
-              .fill(Color.appBackground(for: colorScheme))
-              .withCardShadow()
-          )
-          .contextMenu {
-            Button {
-              modelContext.delete(food)
-            } label: {
-              Label("foods.recent.remove", systemImage: "trash")
+        Button {
+          Task { await rehydrate(food) }
+        } label: {
+          RecentFoodCellView(food: food)
+            .overlay(alignment: .trailing) {
+              if loadingFdcId == food.fdcId {
+                ProgressView()
+                  .padding(.trailing)
+              }
             }
+        }
+        .buttonStyle(.plain)
+        .disabled(loadingFdcId != nil)
+        .padding(.vertical)
+        .background(
+          RoundedRectangle(cornerRadius: .cornerRadius)
+            .fill(Color.appBackground(for: colorScheme))
+            .withCardShadow()
+        )
+        .contextMenu {
+          Button {
+            modelContext.delete(food)
+          } label: {
+            Label("foods.recent.remove", systemImage: "trash")
           }
+        }
+      }
+      .navigationDestination(item: $navigationTarget) { food in
+        FoodDetailView(food: food)
+      }
+      .alert(
+        "foods.recent.fetch.error",
+        isPresented: Binding(
+          get: { fetchError != nil },
+          set: { if !$0 { fetchError = nil } }
+        ),
+        presenting: fetchError
+      ) { _ in
+        Button("alert.dismiss", role: .cancel) { fetchError = nil }
+      } message: { error in
+        Text(error.message)
       }
     } else {
       VStack(alignment: .leading) {
@@ -57,6 +96,20 @@ struct RecentFoodsListView: View {
           .fill(Color.appBackground(for: colorScheme))
           .withCardShadow()
       )
+    }
+  }
+
+  @MainActor
+  private func rehydrate(_ food: RecentFood) async {
+    guard loadingFdcId == nil else { return }
+    loadingFdcId = food.fdcId
+    defer { loadingFdcId = nil }
+    do {
+      let item = try await service.fetchFood(by: food.fdcId)
+      navigationTarget = item
+    } catch {
+      fetchError = FetchError(
+        message: String(localized: "foods.recent.fetch.error.message"))
     }
   }
 }

--- a/KFinder/Resources/Localizable.xcstrings
+++ b/KFinder/Resources/Localizable.xcstrings
@@ -105,6 +105,26 @@
         }
       }
     },
+    "foods.recent.fetch.error" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Couldn't load food details"
+          }
+        }
+      }
+    },
+    "foods.recent.fetch.error.message" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Check your connection and try again."
+          }
+        }
+      }
+    },
     "foods.recent.none" : {
       "localizations" : {
         "en" : {

--- a/KFinderTests/FoodDataCentralServiceTests.swift
+++ b/KFinderTests/FoodDataCentralServiceTests.swift
@@ -23,8 +23,8 @@ final class MockURLProtocol: URLProtocol, @unchecked Sendable {
   nonisolated(unsafe) static var responder:
     (@Sendable (URLRequest) -> MockResponse)?
 
-  override class func canInit(with request: URLRequest) -> Bool { true }
-  override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+  override static func canInit(with request: URLRequest) -> Bool { true }
+  override static func canonicalRequest(for request: URLRequest) -> URLRequest {
     request
   }
 

--- a/KFinderTests/FoodDataCentralServiceTests.swift
+++ b/KFinderTests/FoodDataCentralServiceTests.swift
@@ -1,0 +1,177 @@
+//
+// SPDX-FileCopyrightText: (c) 2026 Robert Tucker
+// SPDX-License-Identifier: MIT
+//
+
+import Foundation
+import Models
+import Services
+import Testing
+
+// MARK: - URLProtocol stub
+
+// Mocks a single response per request by inspecting the URL. Tests register
+// expected (status, body) tuples keyed by URL path before exercising the
+// service; this intercepts the actual network call.
+final class MockURLProtocol: URLProtocol, @unchecked Sendable {
+  nonisolated(unsafe) static var responder:
+    (@Sendable (URLRequest) -> (HTTPURLResponse, Data?, Error?))?
+
+  override class func canInit(with request: URLRequest) -> Bool { true }
+  override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    request
+  }
+
+  override func startLoading() {
+    guard let responder = MockURLProtocol.responder else {
+      client?.urlProtocol(
+        self,
+        didFailWithError: NSError(
+          domain: "MockURLProtocol", code: -1,
+          userInfo: [NSLocalizedDescriptionKey: "no responder registered"]))
+      return
+    }
+    let (response, data, error) = responder(request)
+    if let error = error {
+      client?.urlProtocol(self, didFailWithError: error)
+      return
+    }
+    client?.urlProtocol(
+      self, didReceive: response, cacheStoragePolicy: .notAllowed)
+    if let data = data {
+      client?.urlProtocol(self, didLoad: data)
+    }
+    client?.urlProtocolDidFinishLoading(self)
+  }
+
+  override func stopLoading() {}
+
+  static func makeSession() -> URLSession {
+    let config = URLSessionConfiguration.ephemeral
+    config.protocolClasses = [MockURLProtocol.self]
+    return URLSession(configuration: config)
+  }
+}
+
+// MARK: - fetchFood Tests
+
+@Suite("FoodDataCentralService.fetchFood", .serialized)
+struct FoodDataCentralServiceTests {
+
+  private func makeService() -> (FoodDataCentralService, URLSession) {
+    let session = MockURLProtocol.makeSession()
+    let service = FoodDataCentralService(apiKey: "test-key", session: session)
+    return (service, session)
+  }
+
+  private func stage(
+    status: Int, body: Data?, error: Error? = nil
+  ) {
+    MockURLProtocol.responder = { request in
+      let response = HTTPURLResponse(
+        url: request.url!, statusCode: status,
+        httpVersion: nil, headerFields: nil)!
+      return (response, body, error)
+    }
+  }
+
+  // Minimal payload mirroring the real /food/{id}?format=full shape. Enough
+  // surface area to verify the mapping picks up every FoodItem field.
+  private func sampleDetailJSON(fdcId: Int = 2_341_130) -> Data {
+    let json = """
+    {
+      "fdcId": \(fdcId),
+      "description": "Cheese, Muenster, reduced fat",
+      "dataType": "Survey (FNDDS)",
+      "foodClass": "Survey",
+      "foodCode": "14107250",
+      "publicationDate": "10/28/2022",
+      "wweiaFoodCategory": {
+        "wweiaFoodCategoryCode": 1602,
+        "wweiaFoodCategoryDescription": "Cheese"
+      },
+      "foodAttributes": [
+        {"id": 1, "value": "lowfat", "sequenceNumber": 1,
+         "foodAttributeType": {"id": 1001, "name": "Additional Description"}},
+        {"id": 2, "value": "part skim", "sequenceNumber": 2,
+         "foodAttributeType": {"id": 1001, "name": "Additional Description"}},
+        {"id": 3, "value": 1602, "name": "WWEIA Category number",
+         "foodAttributeType": {"id": 999, "name": "Attribute"}}
+      ],
+      "foodNutrients": [
+        {"type": "FoodNutrient",
+         "nutrient": {"id": 2045, "number": "951", "name": "Proximates",
+                      "rank": 50, "unitName": "g"}},
+        {"type": "FoodNutrient", "id": 28564574, "amount": 24.7,
+         "nutrient": {"id": 1003, "number": "203", "name": "Protein",
+                      "rank": 600, "unitName": "g"}},
+        {"type": "FoodNutrient", "id": 28564601, "amount": 1.5,
+         "nutrient": {"id": 1185, "number": "430",
+                      "name": "Vitamin K (phylloquinone)",
+                      "rank": 8800, "unitName": "ug"}}
+      ],
+      "foodPortions": [
+        {"id": 269081, "gramWeight": 9, "modifier": "1 cracker-size slice",
+         "portionDescription": "Quantity not specified", "sequenceNumber": 1},
+        {"id": 269083, "gramWeight": 113, "modifier": "1 cup, shredded",
+         "portionDescription": "Quantity not specified", "sequenceNumber": 3}
+      ]
+    }
+    """
+    return Data(json.utf8)
+  }
+
+  @Test("maps a 200 response into a populated FoodItem")
+  func mapsSuccess() async throws {
+    let (service, _) = makeService()
+    stage(status: 200, body: sampleDetailJSON())
+
+    let food = try await service.fetchFood(by: 2_341_130)
+
+    #expect(food.id == 2_341_130)
+    #expect(food.name == "Cheese, Muenster, reduced fat")
+    #expect(food.dataType == "Survey (FNDDS)")
+    #expect(food.category == "Cheese")
+    #expect(food.extra == "lowfat;part skim")
+    // 3 nutrients in payload, 1 is a category header (no id/amount) → 2 kept.
+    #expect(food.nutrients?.count == 2)
+    #expect(food.nutrients?.contains { $0.number == "430" } == true)
+    #expect(food.measures?.count == 2)
+    #expect(food.measures?.first?.text == "1 cracker-size slice")
+  }
+
+  @Test("translates 404 into FoodDataCentralError.notFound")
+  func translatesNotFound() async throws {
+    let (service, _) = makeService()
+    stage(status: 404, body: Data())
+
+    await #expect(throws: FoodDataCentralError.notFound) {
+      _ = try await service.fetchFood(by: 9_999_999)
+    }
+  }
+
+  @Test("translates non-success status into unexpectedStatus")
+  func translatesUnexpectedStatus() async throws {
+    let (service, _) = makeService()
+    stage(status: 500, body: Data())
+
+    do {
+      _ = try await service.fetchFood(by: 1)
+      Issue.record("expected throw")
+    } catch FoodDataCentralError.unexpectedStatus(let code) {
+      #expect(code == 500)
+    } catch {
+      Issue.record("unexpected error: \(error)")
+    }
+  }
+
+  @Test("translates a malformed body into FoodDataCentralError.decoding")
+  func translatesDecodingError() async throws {
+    let (service, _) = makeService()
+    stage(status: 200, body: Data("{ not json".utf8))
+
+    await #expect(throws: FoodDataCentralError.decoding) {
+      _ = try await service.fetchFood(by: 1)
+    }
+  }
+}

--- a/KFinderTests/FoodDataCentralServiceTests.swift
+++ b/KFinderTests/FoodDataCentralServiceTests.swift
@@ -11,11 +11,17 @@ import Testing
 // MARK: - URLProtocol stub
 
 // Mocks a single response per request by inspecting the URL. Tests register
-// expected (status, body) tuples keyed by URL path before exercising the
-// service; this intercepts the actual network call.
+// a `MockResponse` before exercising the service; this intercepts the actual
+// network call.
+struct MockResponse: Sendable {
+  let response: HTTPURLResponse
+  let data: Data?
+  let error: Error?
+}
+
 final class MockURLProtocol: URLProtocol, @unchecked Sendable {
   nonisolated(unsafe) static var responder:
-    (@Sendable (URLRequest) -> (HTTPURLResponse, Data?, Error?))?
+    (@Sendable (URLRequest) -> MockResponse)?
 
   override class func canInit(with request: URLRequest) -> Bool { true }
   override class func canonicalRequest(for request: URLRequest) -> URLRequest {
@@ -31,14 +37,14 @@ final class MockURLProtocol: URLProtocol, @unchecked Sendable {
           userInfo: [NSLocalizedDescriptionKey: "no responder registered"]))
       return
     }
-    let (response, data, error) = responder(request)
-    if let error = error {
+    let mock = responder(request)
+    if let error = mock.error {
       client?.urlProtocol(self, didFailWithError: error)
       return
     }
     client?.urlProtocol(
-      self, didReceive: response, cacheStoragePolicy: .notAllowed)
-    if let data = data {
+      self, didReceive: mock.response, cacheStoragePolicy: .notAllowed)
+    if let data = mock.data {
       client?.urlProtocol(self, didLoad: data)
     }
     client?.urlProtocolDidFinishLoading(self)
@@ -71,7 +77,7 @@ struct FoodDataCentralServiceTests {
       let response = HTTPURLResponse(
         url: request.url!, statusCode: status,
         httpVersion: nil, headerFields: nil)!
-      return (response, body, error)
+      return MockResponse(response: response, data: body, error: error)
     }
   }
 

--- a/Packages/Models/Sources/Models/FoodDataCentral/FoodDetailResponse.swift
+++ b/Packages/Models/Sources/Models/FoodDataCentral/FoodDetailResponse.swift
@@ -1,0 +1,183 @@
+//
+// SPDX-FileCopyrightText: (c) 2026 Robert Tucker
+// SPDX-License-Identifier: MIT
+//
+
+import Foundation
+
+// Shape returned by GET /fdc/v1/food/{fdcId}?format=full.
+// This is a different shape than `SearchFoodItem` (which models the search-hit
+// projection) — `nutrient` is nested, `amount` replaces `value`, dates use
+// "M/d/yyyy" instead of "yyyy-MM-dd", and portions live under `foodPortions`
+// rather than `foodMeasures`. Kept as a distinct Codable so the two API
+// surfaces can evolve independently. See issue #96.
+public struct FoodDetailResponse: Codable, Sendable {
+  public let fdcId: Int
+  public let description: String
+  // FNDDS may report this as "Survey (FNDDS)" or as a `foodClass` value.
+  public let dataType: String?
+  public let foodClass: String?
+  // FDC publishes detail dates as "M/d/yyyy" — distinct from search's
+  // "yyyy-MM-dd" formatting.
+  public let publicationDate: String?
+  public let wweiaFoodCategory: WWEIAFoodCategory?
+  public let foodAttributes: [DetailFoodAttribute]?
+  public let foodNutrients: [DetailFoodNutrient]
+  public let foodPortions: [DetailFoodPortion]?
+
+  public init(
+    fdcId: Int, description: String,
+    dataType: String? = nil, foodClass: String? = nil,
+    publicationDate: String? = nil,
+    wweiaFoodCategory: WWEIAFoodCategory? = nil,
+    foodAttributes: [DetailFoodAttribute]? = nil,
+    foodNutrients: [DetailFoodNutrient] = [],
+    foodPortions: [DetailFoodPortion]? = nil
+  ) {
+    self.fdcId = fdcId
+    self.description = description
+    self.dataType = dataType
+    self.foodClass = foodClass
+    self.publicationDate = publicationDate
+    self.wweiaFoodCategory = wweiaFoodCategory
+    self.foodAttributes = foodAttributes
+    self.foodNutrients = foodNutrients
+    self.foodPortions = foodPortions
+  }
+}
+
+public struct WWEIAFoodCategory: Codable, Sendable {
+  public let wweiaFoodCategoryCode: Int?
+  public let wweiaFoodCategoryDescription: String?
+
+  public init(
+    wweiaFoodCategoryCode: Int? = nil,
+    wweiaFoodCategoryDescription: String? = nil
+  ) {
+    self.wweiaFoodCategoryCode = wweiaFoodCategoryCode
+    self.wweiaFoodCategoryDescription = wweiaFoodCategoryDescription
+  }
+}
+
+public struct DetailFoodAttribute: Codable, Sendable {
+  public let id: Int?
+  // FDC encodes `value` heterogeneously across attribute types (String for
+  // descriptions, Int for category codes). We only care about the String
+  // case; everything else decodes to nil and the consumer skips it.
+  public let value: String?
+  public let sequenceNumber: Int?
+  public let name: String?
+  public let foodAttributeType: DetailFoodAttributeType?
+
+  enum CodingKeys: String, CodingKey {
+    case id, value, sequenceNumber, name, foodAttributeType
+  }
+
+  public init(
+    id: Int? = nil, value: String? = nil,
+    sequenceNumber: Int? = nil, name: String? = nil,
+    foodAttributeType: DetailFoodAttributeType? = nil
+  ) {
+    self.id = id
+    self.value = value
+    self.sequenceNumber = sequenceNumber
+    self.name = name
+    self.foodAttributeType = foodAttributeType
+  }
+
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    self.id = try container.decodeIfPresent(Int.self, forKey: .id)
+    self.sequenceNumber = try container.decodeIfPresent(
+      Int.self, forKey: .sequenceNumber)
+    self.name = try container.decodeIfPresent(String.self, forKey: .name)
+    self.foodAttributeType = try container.decodeIfPresent(
+      DetailFoodAttributeType.self, forKey: .foodAttributeType)
+    self.value = try? container.decodeIfPresent(String.self, forKey: .value)
+  }
+}
+
+public struct DetailFoodAttributeType: Codable, Sendable {
+  public let id: Int?
+  public let name: String?
+  public let description: String?
+
+  public init(id: Int? = nil, name: String? = nil, description: String? = nil) {
+    self.id = id
+    self.name = name
+    self.description = description
+  }
+}
+
+public struct DetailFoodNutrient: Codable, Sendable {
+  public let id: Int?
+  public let amount: Double?
+  public let nutrient: DetailNutrient?
+  public let type: String?
+
+  public init(
+    id: Int? = nil, amount: Double? = nil,
+    nutrient: DetailNutrient? = nil, type: String? = nil
+  ) {
+    self.id = id
+    self.amount = amount
+    self.nutrient = nutrient
+    self.type = type
+  }
+}
+
+public struct DetailNutrient: Codable, Sendable {
+  public let id: Int?
+  public let number: String?
+  public let name: String?
+  public let unitName: String?
+  public let rank: Int?
+
+  public init(
+    id: Int? = nil, number: String? = nil, name: String? = nil,
+    unitName: String? = nil, rank: Int? = nil
+  ) {
+    self.id = id
+    self.number = number
+    self.name = name
+    self.unitName = unitName
+    self.rank = rank
+  }
+}
+
+public struct DetailFoodPortion: Codable, Sendable {
+  public let id: Int
+  public let gramWeight: Double
+  public let measureUnit: DetailMeasureUnit?
+  public let modifier: String?
+  public let portionDescription: String?
+  public let sequenceNumber: Int?
+
+  public init(
+    id: Int, gramWeight: Double,
+    measureUnit: DetailMeasureUnit? = nil,
+    modifier: String? = nil, portionDescription: String? = nil,
+    sequenceNumber: Int? = nil
+  ) {
+    self.id = id
+    self.gramWeight = gramWeight
+    self.measureUnit = measureUnit
+    self.modifier = modifier
+    self.portionDescription = portionDescription
+    self.sequenceNumber = sequenceNumber
+  }
+}
+
+public struct DetailMeasureUnit: Codable, Sendable {
+  public let id: Int?
+  public let name: String?
+  public let abbreviation: String?
+
+  public init(
+    id: Int? = nil, name: String? = nil, abbreviation: String? = nil
+  ) {
+    self.id = id
+    self.name = name
+    self.abbreviation = abbreviation
+  }
+}

--- a/Packages/Models/Sources/Models/FoodItem+FoodDetailResponse.swift
+++ b/Packages/Models/Sources/Models/FoodItem+FoodDetailResponse.swift
@@ -1,0 +1,71 @@
+//
+// SPDX-FileCopyrightText: (c) 2026 Robert Tucker
+// SPDX-License-Identifier: MIT
+//
+
+import Foundation
+
+extension FoodItem {
+  // Maps the `/food/{fdcId}?format=full` payload (issue #96). Filters out
+  // header rows in `foodNutrients` (Proximates, Minerals, …) that have no
+  // `id`/`amount`, and prefers `modifier` text for portions because the
+  // FNDDS `portionDescription` is usually a generic "Quantity not specified".
+  public convenience init(from response: FoodDetailResponse) {
+    let dateFormatter = DateFormatter()
+    dateFormatter.locale = Locale(identifier: "en_US_POSIX")
+    dateFormatter.dateFormat = "M/d/yyyy"
+
+    let extra = response.foodAttributes?
+      .filter { $0.foodAttributeType?.name == "Additional Description" }
+      .compactMap { attribute -> (Int, String)? in
+        guard let value = attribute.value, !value.isEmpty else { return nil }
+        return (attribute.sequenceNumber ?? Int.max, value)
+      }
+      .sorted { $0.0 < $1.0 }
+      .map { $0.1 }
+      .joined(separator: ";")
+      .nonEmpty
+
+    let nutrients: [FoodNutrient] = response.foodNutrients.compactMap { entry in
+      guard let nutrient = entry.nutrient,
+            let amount = entry.amount,
+            let number = nutrient.number else {
+        return nil
+      }
+      return FoodNutrient(
+        number: number,
+        name: nutrient.name ?? "",
+        unitName: nutrient.unitName ?? "",
+        value: amount)
+    }
+
+    let measures: [FoodMeasure] = response.foodPortions?
+      .sorted { ($0.sequenceNumber ?? .max) < ($1.sequenceNumber ?? .max) }
+      .map { portion in
+        let text = portion.modifier?.nonEmpty
+          ?? portion.portionDescription
+          ?? ""
+        return FoodMeasure(
+          id: portion.id,
+          text: text,
+          gramWeight: portion.gramWeight,
+          rank: portion.sequenceNumber ?? 0)
+      } ?? []
+
+    self.init(
+      id: response.fdcId,
+      name: response.description,
+      extra: extra,
+      dataType: response.dataType ?? response.foodClass
+        ?? FoodSearchCriteria.DataSet.unspecified.rawValue,
+      category: response.wweiaFoodCategory?.wweiaFoodCategoryDescription,
+      publishedOn: response.publicationDate
+        .flatMap { dateFormatter.date(from: $0) } ?? Date.distantPast,
+      nutrients: nutrients,
+      measures: measures)
+  }
+}
+
+extension String {
+  fileprivate var nonEmpty: String? { isEmpty ? nil : self }
+}

--- a/Packages/Models/Sources/Models/FoodItem.swift
+++ b/Packages/Models/Sources/Models/FoodItem.swift
@@ -48,6 +48,65 @@ import SwiftData
     self.nutrients = from.foodNutrients?.map { FoodNutrient(from: $0) } ?? []
     self.measures = from.foodMeasures?.map { FoodMeasure(from: $0) } ?? []
   }
+
+  // Maps the `/food/{fdcId}?format=full` payload (issue #96). Filters out
+  // header rows in `foodNutrients` (Proximates, Minerals, …) that have no
+  // `id`/`amount`, and prefers `modifier` text for portions because the
+  // FNDDS `portionDescription` is usually a generic "Quantity not specified".
+  public init(from response: FoodDetailResponse) {
+    self.id = response.fdcId
+    self.name = response.description
+    self.dataType = response.dataType ?? response.foodClass
+      ?? FoodSearchCriteria.DataSet.unspecified.rawValue
+    self.category = response.wweiaFoodCategory?.wweiaFoodCategoryDescription
+
+    self.extra = response.foodAttributes?
+      .filter { $0.foodAttributeType?.name == "Additional Description" }
+      .compactMap { attribute -> (Int, String)? in
+        guard let value = attribute.value, !value.isEmpty else { return nil }
+        return (attribute.sequenceNumber ?? Int.max, value)
+      }
+      .sorted { $0.0 < $1.0 }
+      .map { $0.1 }
+      .joined(separator: ";")
+      .nonEmpty
+
+    let dateFormatter = DateFormatter()
+    dateFormatter.locale = Locale(identifier: "en_US_POSIX")
+    dateFormatter.dateFormat = "M/d/yyyy"
+    self.publishedOn = response.publicationDate
+      .flatMap { dateFormatter.date(from: $0) } ?? Date.distantPast
+
+    self.nutrients = response.foodNutrients.compactMap { entry in
+      guard let nutrient = entry.nutrient,
+            let amount = entry.amount,
+            let number = nutrient.number else {
+        return nil
+      }
+      return FoodNutrient(
+        number: number,
+        name: nutrient.name ?? "",
+        unitName: nutrient.unitName ?? "",
+        value: amount)
+    }
+
+    self.measures = response.foodPortions?
+      .sorted { ($0.sequenceNumber ?? .max) < ($1.sequenceNumber ?? .max) }
+      .map { portion in
+        let text = portion.modifier?.nonEmpty
+          ?? portion.portionDescription
+          ?? ""
+        return FoodMeasure(
+          id: portion.id,
+          text: text,
+          gramWeight: portion.gramWeight,
+          rank: portion.sequenceNumber ?? 0)
+      } ?? []
+  }
+}
+
+extension String {
+  fileprivate var nonEmpty: String? { isEmpty ? nil : self }
 }
 
 // MARK: - Samples

--- a/Packages/Models/Sources/Models/FoodItem.swift
+++ b/Packages/Models/Sources/Models/FoodItem.swift
@@ -49,64 +49,6 @@ import SwiftData
     self.measures = from.foodMeasures?.map { FoodMeasure(from: $0) } ?? []
   }
 
-  // Maps the `/food/{fdcId}?format=full` payload (issue #96). Filters out
-  // header rows in `foodNutrients` (Proximates, Minerals, …) that have no
-  // `id`/`amount`, and prefers `modifier` text for portions because the
-  // FNDDS `portionDescription` is usually a generic "Quantity not specified".
-  public init(from response: FoodDetailResponse) {
-    self.id = response.fdcId
-    self.name = response.description
-    self.dataType = response.dataType ?? response.foodClass
-      ?? FoodSearchCriteria.DataSet.unspecified.rawValue
-    self.category = response.wweiaFoodCategory?.wweiaFoodCategoryDescription
-
-    self.extra = response.foodAttributes?
-      .filter { $0.foodAttributeType?.name == "Additional Description" }
-      .compactMap { attribute -> (Int, String)? in
-        guard let value = attribute.value, !value.isEmpty else { return nil }
-        return (attribute.sequenceNumber ?? Int.max, value)
-      }
-      .sorted { $0.0 < $1.0 }
-      .map { $0.1 }
-      .joined(separator: ";")
-      .nonEmpty
-
-    let dateFormatter = DateFormatter()
-    dateFormatter.locale = Locale(identifier: "en_US_POSIX")
-    dateFormatter.dateFormat = "M/d/yyyy"
-    self.publishedOn = response.publicationDate
-      .flatMap { dateFormatter.date(from: $0) } ?? Date.distantPast
-
-    self.nutrients = response.foodNutrients.compactMap { entry in
-      guard let nutrient = entry.nutrient,
-            let amount = entry.amount,
-            let number = nutrient.number else {
-        return nil
-      }
-      return FoodNutrient(
-        number: number,
-        name: nutrient.name ?? "",
-        unitName: nutrient.unitName ?? "",
-        value: amount)
-    }
-
-    self.measures = response.foodPortions?
-      .sorted { ($0.sequenceNumber ?? .max) < ($1.sequenceNumber ?? .max) }
-      .map { portion in
-        let text = portion.modifier?.nonEmpty
-          ?? portion.portionDescription
-          ?? ""
-        return FoodMeasure(
-          id: portion.id,
-          text: text,
-          gramWeight: portion.gramWeight,
-          rank: portion.sequenceNumber ?? 0)
-      } ?? []
-  }
-}
-
-extension String {
-  fileprivate var nonEmpty: String? { isEmpty ? nil : self }
 }
 
 // MARK: - Samples

--- a/Packages/Services/Sources/Services/FoodDataCentralService.swift
+++ b/Packages/Services/Sources/Services/FoodDataCentralService.swift
@@ -7,17 +7,28 @@ import Foundation
 import Models
 import os
 
+public enum FoodDataCentralError: Error, Equatable, Sendable {
+  case notFound
+  case unexpectedStatus(Int)
+  case decoding
+  case transport
+}
+
 public struct FoodDataCentralService {
   private let logger = Logger(
     subsystem: Bundle.main.bundleIdentifier!,
     category: String(describing: FoodDataCentralService.self))
 
   private let apiKey: String
+  private let session: URLSession
   private let apiKeyHeader = "X-Api-Key"
   private let baseURL = URL(string: "https://api.nal.usda.gov/fdc/v1")
 
-  public init(apiKey: String) {
+  // `session` is injectable so tests can intercept via URLProtocol; the
+  // default points at the shared session (production behavior unchanged).
+  public init(apiKey: String, session: URLSession = .shared) {
     self.apiKey = apiKey
+    self.session = session
   }
 
   public func searchFoods(for query: String) async -> FoodSearchResult? {
@@ -26,7 +37,7 @@ public struct FoodDataCentralService {
 
     do {
       logger.debug("\(request.httpMethod!) \(request.url!)")
-      let (data, _) = try await URLSession.shared.data(for: request)
+      let (data, _) = try await session.data(for: request)
       let result = try JSONDecoder().decode(FoodSearchResult.self, from: data)
       logger.debug("search returned with \(result.totalHits) hit(s)")
       return result
@@ -34,6 +45,41 @@ public struct FoodDataCentralService {
       logger.error("\(error, privacy: .public)")
     }
     return nil
+  }
+
+  // Re-hydrates a `RecentFood` into a fully-populated `FoodItem` by hitting
+  // /food/{fdcId}?format=full. Unlike `searchFoods`, the failure modes here
+  // are exceptional (the caller has an fdcId they expect to resolve), so
+  // errors throw rather than silently returning nil. See issue #96.
+  public func fetchFood(by fdcId: Int) async throws -> FoodItem {
+    let request = buildFoodURLRequest(with: fdcId)
+    logger.debug("\(request.httpMethod!) \(request.url!)")
+
+    let data: Data
+    let response: URLResponse
+    do {
+      (data, response) = try await session.data(for: request)
+    } catch {
+      logger.error("fetchFood transport error: \(error, privacy: .public)")
+      throw FoodDataCentralError.transport
+    }
+
+    if let status = (response as? HTTPURLResponse)?.statusCode {
+      if status == 404 { throw FoodDataCentralError.notFound }
+      guard (200..<300).contains(status) else {
+        logger.error("fetchFood unexpected status: \(status)")
+        throw FoodDataCentralError.unexpectedStatus(status)
+      }
+    }
+
+    do {
+      let detail = try JSONDecoder().decode(
+        FoodDetailResponse.self, from: data)
+      return FoodItem(from: detail)
+    } catch {
+      logger.error("fetchFood decoding error: \(error, privacy: .public)")
+      throw FoodDataCentralError.decoding
+    }
   }
 
   private func buildSearchURLRequest(with query: String) -> URLRequest {


### PR DESCRIPTION
## Summary

Closes #96 — the last 1.3 milestone issue.

A `RecentFood` is a lightweight projection (display fields + `fdcId`), so tapping a Recents row needs to re-fetch the full `FoodItem` payload from FDC before pushing into `FoodDetailView`. This PR adds the missing service call and wires it through the Recents row.

### Service / Models
- **New** `FoodDataCentralService.fetchFood(by fdcId: Int) async throws -> FoodItem`. Distinct error semantics from `searchFoods` (which silently returns `nil`): the caller has an `fdcId` they expect to resolve, so failures throw. New `FoodDataCentralError` enum: `.notFound` (404), `.unexpectedStatus(Int)` (non-2xx), `.decoding`, `.transport`.
- **Injectable** `URLSession` on `FoodDataCentralService.init(apiKey:, session: URLSession = .shared)` so tests can intercept via `URLProtocol`. Default `.shared` preserves production behavior.
- **New** `FoodDetailResponse` Codable + supporting types in `Packages/Models/Sources/Models/FoodDataCentral/`. The `/food/{id}?format=full` shape is different from search hits (nested `nutrient`, `amount` not `value`, `foodPortions` not `foodMeasures`, `"M/d/yyyy"` dates) — modelled separately so the two API surfaces can evolve independently.
- **New** `FoodItem(from: FoodDetailResponse)` mapper. Filters category-header rows in `foodNutrients` (Proximates, Minerals, …) that have no `id`/`amount`. Prefers `modifier` text for portions because FNDDS `portionDescription` is typically a generic "Quantity not specified".

### UI
- `RecentFoodsListView` row is now a `Button`. Tap kicks off a `Task` that calls `fetchFood`. While in-flight, the cell shows a trailing `ProgressView` and the list disables further taps. On success, sets `@State navigationTarget: FoodItem?` and `.navigationDestination(item:)` pushes the detail view. On failure, raises a localized `.alert` ("Couldn't load food details" / "Check your connection and try again.").
- New localized strings: `foods.recent.fetch.error` and `foods.recent.fetch.error.message`. Reused the existing `alert.dismiss` for the alert button.

### Tests
- New `FoodDataCentralServiceTests` (in `KFinderTests` so it actually runs on CI). URLProtocol mocking via a `URLSessionConfiguration.protocolClasses` injection; 4 tests cover 200-success, 404→`.notFound`, 500→`.unexpectedStatus(500)`, and malformed-body→`.decoding`.

### Manual verification
Smoke-tested end-to-end in the iPhone Air sim. Tapped each Recents row, confirmed:
- The fetched detail view shows correct name, category, citation (with `M/d/yyyy` parsed → `Pub:2024-10-31`), and all nutrients including Vitamin K with the right unit.
- Back navigation returns to Home with the screen hash identical to pre-tap — Recents state unaffected.

## Test plan

- [x] `xcodebuild test -scheme KFinder` green locally
- [x] 4 new URLProtocol-mocked tests pass
- [x] Manual: tap each Recents row, observe spinner → detail view, back returns clean
- [ ] CI green on this PR
- [ ] Manual: error path (kill connectivity, tap → confirm alert)

🤖 Generated with [Claude Code](https://claude.com/claude-code)