### PR TITLE
ci: cache Xcode DerivedData via irgaly/xcode-cache (#101)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,15 +20,17 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
-      - name: Cache SwiftPM dependencies
-        uses: actions/cache@v4
+      # Tier 3: caches the full DerivedData tree (Xcode's real SwiftPM build
+      # outputs + incremental build state) keyed by commit, with source-file
+      # mtime restoration so Xcode trusts unchanged-source equality on hit.
+      # SourcePackages is cached separately keyed by Package.resolved hash.
+      - name: Cache Xcode DerivedData and SwiftPM
+        uses: irgaly/xcode-cache@v1.9.2
         with:
-          path: |
-            ~/Library/Caches/org.swift.swiftpm
-            ~/Library/Developer/Xcode/DerivedData/**/SourcePackages
-          key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
+          key: ${{ runner.os }}-xcode-deriveddata-${{ github.workflow }}-${{ github.sha }}
           restore-keys: |
-            ${{ runner.os }}-spm-
+            ${{ runner.os }}-xcode-deriveddata-${{ github.workflow }}-
+          verbose: true
 
       - name: Build and Test
         run: set -o pipefail && xcodebuild test -scheme KFinder -project KFinder.xcodeproj -destination "platform=iOS Simulator,OS=26.2,name=iPhone Air" | xcpretty && exit ${PIPESTATUS[0]}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -67,6 +67,23 @@ jobs:
       # - name: Setup runtime (example)
       #   uses: actions/setup-example@v1
 
+      # Cache SwiftPM deps only for the Swift analysis job — explicitly NOT
+      # DerivedData. Caching the project's own DerivedData would let Xcode
+      # skip recompiling KFinder sources on a hit, which would silently
+      # cause the CodeQL Swift extractor to miss those compilations and
+      # return an incomplete analysis. SwiftPM dependencies are safe to
+      # cache because the extractor doesn't analyze them anyway.
+      - name: Cache SwiftPM dependencies
+        if: matrix.build-mode == 'manual'
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/Library/Caches/org.swift.swiftpm
+            ~/Library/Developer/Xcode/DerivedData/**/SourcePackages
+          key: ${{ runner.os }}-codeql-spm-${{ hashFiles('**/Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-codeql-spm-
+
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4


### PR DESCRIPTION
Closes #101.

## Summary

PR #99's tier 1+2 cached the SwiftPM SourcePackages glob but only restored ~906 KB of metadata — the actual compiled SwiftPM dependencies and Xcode's incremental build state weren't covered (see #101 for the per-PR build duration evidence). This swaps in an Xcode-aware cache that understands the real DerivedData layout, plus restores source mtimes so the next build trusts unchanged-source equality.

- **`ci.yml`**: replace `actions/cache` with [`irgaly/xcode-cache@v1.9.2`](https://github.com/irgaly/xcode-cache). Keyed by commit SHA with a workflow-scoped `restore-keys` fallback so any prior CI build can be a partial hit. `verbose: true` logs restore/save sizes so we can see what's actually being cached.
- **`codeql.yml`**: add a SwiftPM-only `actions/cache` step to the `Analyze (swift)` job. **Deliberately NOT caching DerivedData here** — a cached hit would let Xcode skip recompiling KFinder sources, which would silently cause the CodeQL Swift extractor to miss those compilations and return an incomplete analysis. Cache namespace is distinct (`codeql-spm`) so it can't collide with the `ci.yml` cache.

## Test plan

- [ ] First CI run on this branch: cold cache (no hit on the `xcode-deriveddata` prefix yet). Should still pass — just save the cache for next runs.
- [ ] Second CI run (e.g. after pushing a no-op commit, or PR re-run): warm cache hit. Compare `build` job duration to PR #98's 4m43s baseline. Expectation: faster, with cache restore size logged in step output.
- [ ] `Analyze (swift)` continues to pass — cache hit on `codeql-spm` should restore SwiftPM deps without affecting extractor coverage.
- [ ] Cache restore/save log lines visible in the workflow output (verifying acceptance criterion 2).

## Risks

- `irgaly/xcode-cache` is community-maintained. v1.9.2 is the current latest. If it breaks or misbehaves, falling back is one revert.
- Cache size will grow vs. tier 1+2 (whole DerivedData vs. 906 KB metadata). Within GitHub's per-repo cache limits, but worth watching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)