### PR TITLE
ci: use OS=latest,iPhone 16 for test destination

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,5 +32,13 @@ jobs:
             ${{ runner.os }}-xcode-deriveddata-${{ github.workflow }}-
           verbose: true
 
+      - name: Diagnostics (simulator environment)
+        run: |
+          echo "=== Selected Xcode ==="; xcode-select -p; xcodebuild -version
+          echo "=== Installed Xcodes ==="; ls -d /Applications/Xcode*.app 2>/dev/null || true
+          echo "=== iOS SDKs ==="; xcodebuild -showsdks 2>/dev/null | grep -i ios || true
+          echo "=== Simulator runtimes ==="; xcrun simctl list runtimes
+          echo "=== Available devices ==="; xcrun simctl list devices available
+
       - name: Build and Test
         run: set -o pipefail && xcodebuild test -scheme KFinder -project KFinder.xcodeproj -destination "platform=iOS Simulator,OS=latest,name=iPhone 16" | xcpretty && exit ${PIPESTATUS[0]}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,17 @@ jobs:
   build:
     runs-on: macos-latest
 
+    # Test the minimum supported iOS line and the latest, skipping the
+    # middle. fail-fast: false so one OS failing still reports the other.
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - ios: "18.6"
+            destination: "platform=iOS Simulator,OS=18.6,name=iPhone 16"
+          - ios: latest
+            destination: "platform=iOS Simulator,OS=latest,name=iPhone 16"
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -37,10 +48,12 @@ jobs:
       - name: Cache Xcode DerivedData and SwiftPM
         uses: irgaly/xcode-cache@v1.9.2
         with:
-          key: ${{ runner.os }}-xcode-deriveddata-${{ github.workflow }}-${{ github.sha }}
+          key: ${{ runner.os }}-xcode-deriveddata-${{ github.workflow }}-${{ matrix.ios }}-${{ github.sha }}
           restore-keys: |
-            ${{ runner.os }}-xcode-deriveddata-${{ github.workflow }}-
+            ${{ runner.os }}-xcode-deriveddata-${{ github.workflow }}-${{ matrix.ios }}-
           verbose: true
 
       - name: Build and Test
-        run: set -o pipefail && xcodebuild test -scheme KFinder -project KFinder.xcodeproj -destination "platform=iOS Simulator,OS=latest,name=iPhone 16" | xcpretty && exit ${PIPESTATUS[0]}
+        env:
+          DESTINATION: ${{ matrix.destination }}
+        run: set -o pipefail && xcodebuild test -scheme KFinder -project KFinder.xcodeproj -destination "$DESTINATION" | xcpretty && exit ${PIPESTATUS[0]}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,4 +33,4 @@ jobs:
           verbose: true
 
       - name: Build and Test
-        run: set -o pipefail && xcodebuild test -scheme KFinder -project KFinder.xcodeproj -destination "platform=iOS Simulator,OS=26.2,name=iPhone Air" | xcpretty && exit ${PIPESTATUS[0]}
+        run: set -o pipefail && xcodebuild test -scheme KFinder -project KFinder.xcodeproj -destination "platform=iOS Simulator,OS=latest,name=iPhone 16" | xcpretty && exit ${PIPESTATUS[0]}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,16 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
+      # Pin Xcode explicitly. macos-latest ships multiple Xcode versions
+      # (16.x and 26.x) and its default selection is non-deterministic
+      # across the image rollout, which leaves xcodebuild unable to resolve
+      # an iOS Simulator destination on some runners. latest-stable tracks
+      # the toolchain used for local development.
+      - name: Select Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
+
       # Tier 3: caches the full DerivedData tree (Xcode's real SwiftPM build
       # outputs + incremental build state) keyed by commit, with source-file
       # mtime restoration so Xcode trusts unchanged-source equality on hit.
@@ -31,14 +41,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-xcode-deriveddata-${{ github.workflow }}-
           verbose: true
-
-      - name: Diagnostics (simulator environment)
-        run: |
-          echo "=== Selected Xcode ==="; xcode-select -p; xcodebuild -version
-          echo "=== Installed Xcodes ==="; ls -d /Applications/Xcode*.app 2>/dev/null || true
-          echo "=== iOS SDKs ==="; xcodebuild -showsdks 2>/dev/null | grep -i ios || true
-          echo "=== Simulator runtimes ==="; xcrun simctl list runtimes
-          echo "=== Available devices ==="; xcrun simctl list devices available
 
       - name: Build and Test
         run: set -o pipefail && xcodebuild test -scheme KFinder -project KFinder.xcodeproj -destination "platform=iOS Simulator,OS=latest,name=iPhone 16" | xcpretty && exit ${PIPESTATUS[0]}


### PR DESCRIPTION
## Problem

The scheduled `CI Build` run [27902727433](https://github.com/robertwtucker/kfinderapp-ios/actions/runs/27902727433/job/82565852188) failed at destination resolution (exit code 70, before any test ran):

\`\`\`
xcodebuild: error: Unable to find a device matching the provided destination specifier:
		{ platform:iOS Simulator, OS:26.2, name:iPhone Air }
\`\`\`

A PR run ~50 min earlier on the same commit passed. The difference is the `macos-latest` runner image — GitHub rolls image updates gradually, so the pinned `OS=26.2,name=iPhone Air` pairing isn't present on every runner. This is environmental, not a code regression.

## Fix

Stop pinning the exact OS version. Use `OS=latest` with a baseline device, matching the pattern already in `codeql.yml`, so the destination survives runtime bumps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)